### PR TITLE
moved over rollbar and logging signal handlers

### DIFF
--- a/mbq/ranch/signal_handlers/rollbar_handlers.py
+++ b/mbq/ranch/signal_handlers/rollbar_handlers.py
@@ -1,0 +1,22 @@
+import rollbar
+from celery.signals import task_failure, task_rejected, task_unknown
+
+from ..lib.error_handling import log_errors_and_send_to_rollbar
+
+
+@task_failure.connect
+@log_errors_and_send_to_rollbar
+def handle_task_failure(**kw):
+    rollbar.report_exc_info(extra_data=kw)
+
+
+@task_rejected.connect
+@log_errors_and_send_to_rollbar
+def handle_task_rejected(**kw):
+    rollbar.report_exc_info(extra_data=kw)
+
+
+@task_unknown.connect
+@log_errors_and_send_to_rollbar
+def handle_task_unknown(**kw):
+    rollbar.report_exc_info(extra_data=kw)


### PR DESCRIPTION
Opportunistic change.
We copy paste these 4 random signal handlers in each service we use celery... this just moves them to ranch to be with the rest of the celery signal handlers.